### PR TITLE
Typescript enhancements and README addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Once the spotify authentication flow is done, the plugin will display the list o
 
 You can then take the `id` from the Spotify device that you want to control and this is what you put in the plugin's configuration as the `spotifyDeviceId`.
 
+You can also use the [Spotify developer console](https://developer.spotify.com/console/get-users-available-devices/) to get the available devices on your account.
+
 ## Issues and Questions
 
 If you run into issues or you need help please use the [issues template](https://github.com/poblouin/homebridge-spotify-speaker/issues/new/choose). Fill all the relevant sections and submit your issue. It is important that you use the templates because I will automatically be assigned to your issue and I will receive an email. If you use the blank template without assigning me, I will most likely miss the Github notification since I have too many of them with work, I can't read them all.
@@ -102,6 +104,12 @@ Common issues related to that though could be:
 - The Homebridge instance on which this plugin is installed is not on the same network as the Spotify device
 - The Spotify device is currently tied to another user account. Example, you authenticated this plugin using your account, and the Spotify device was last played with your SO's account.
 - The device is in sleep mode. Any devices that sleeps (e.g. a computer) won't be available via the API.
+
+### Amazon Alexa device not responding
+
+Some devices (notably Amazon Alexa devices) will show an `id` like `00000000-0000-0000-0000-000000000000_amzn_1`. However, in some cases, Spotify doesn't like the `_amzn_1` suffix.
+
+To try it before changing the Homebridge plugin settings, test the [Start/Resume Playback API](https://developer.spotify.com/console/put-play/) in the Spotify developer console. Try setting the `device_id` to the `id` with and without the `_amzn_#` suffix.
 
 ## Contributors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@types/node": "^18.11.18",
+        "@types/spotify-web-api-node": "^5.0.7",
         "@typescript-eslint/eslint-plugin": "^5.48.1",
         "@typescript-eslint/parser": "^5.48.1",
         "eslint": "^8.31.0",
@@ -258,6 +259,21 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
+    },
+    "node_modules/@types/spotify-api": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/spotify-api/-/spotify-api-0.0.20.tgz",
+      "integrity": "sha512-HRBwiOthYAT0r/vUQlGlNTdXMnPg/CS3MzTuQKDy2PtalUDXhj0Ep9YZ4tXmL68K0j7FMcLFcYTzy7k7nVu5mg==",
+      "dev": true
+    },
+    "node_modules/@types/spotify-web-api-node": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@types/spotify-web-api-node/-/spotify-web-api-node-5.0.7.tgz",
+      "integrity": "sha512-8ajd4xS3+l4Zau1OyggPv7DjeSFEIGYvG5Q8PbbBMKiaRFD53IkcvU4Bx4Ijyzw+l+Kc09L5L+MXRj0wyVLx9Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/spotify-api": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.48.1",
@@ -4088,6 +4104,21 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
       "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
+    },
+    "@types/spotify-api": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/spotify-api/-/spotify-api-0.0.20.tgz",
+      "integrity": "sha512-HRBwiOthYAT0r/vUQlGlNTdXMnPg/CS3MzTuQKDy2PtalUDXhj0Ep9YZ4tXmL68K0j7FMcLFcYTzy7k7nVu5mg==",
+      "dev": true
+    },
+    "@types/spotify-web-api-node": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/@types/spotify-web-api-node/-/spotify-web-api-node-5.0.7.tgz",
+      "integrity": "sha512-8ajd4xS3+l4Zau1OyggPv7DjeSFEIGYvG5Q8PbbBMKiaRFD53IkcvU4Bx4Ijyzw+l+Kc09L5L+MXRj0wyVLx9Q==",
+      "dev": true,
+      "requires": {
+        "@types/spotify-api": "*"
+      }
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.48.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@types/node": "^18.11.18",
+    "@types/spotify-web-api-node": "^5.0.7",
     "@typescript-eslint/eslint-plugin": "^5.48.1",
     "@typescript-eslint/parser": "^5.48.1",
     "eslint": "^8.31.0",

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -52,7 +52,7 @@ export class HomebridgeSpotifySpeakerPlatform implements DynamicPlatformPlugin {
       this.spotifyApiWrapper.persistTokens();
     });
 
-    setInterval(() => this.spotifyApiWrapper.refreshTokens(), DAY_INTERVAL);
+    setInterval(async () => await this.spotifyApiWrapper.refreshTokens(), DAY_INTERVAL);
   }
 
   configureAccessory(accessory: PlatformAccessory) {
@@ -132,7 +132,7 @@ export class HomebridgeSpotifySpeakerPlatform implements DynamicPlatformPlugin {
   private async logAvailableSpotifyDevices(): Promise<void> {
     const spotifyDevices = await this.spotifyApiWrapper.getMyDevices();
 
-    if (spotifyDevices.length === 0) {
+    if (!spotifyDevices || spotifyDevices.length === 0) {
       this.log.warn(
         'No available spotify devices found, make sure that the speaker you configured is On and visible by Spotify Connect',
       );

--- a/src/spotify-api-wrapper.ts
+++ b/src/spotify-api-wrapper.ts
@@ -66,13 +66,10 @@ export class SpotifyApiWrapper {
     }
   }
 
-  async play(deviceId: string, contextUri: string, uris?: string, offset?: number, positionMs?: number) {
+  async play(deviceId: string, contextUri: string) {
     const options = {
       device_id: deviceId,
       context_uri: contextUri,
-      ...(uris && { uris }),
-      ...(offset && { offset }),
-      ...(positionMs && { position_ms: positionMs }),
     };
 
     await this.wrappedRequest(() => this.spotifyApi.play(options));

--- a/src/spotify-speaker-accessory.ts
+++ b/src/spotify-speaker-accessory.ts
@@ -67,9 +67,9 @@ export class SpotifySpeakerAccessory {
     try {
       if (value) {
         await this.platform.spotifyApiWrapper.play(this.device.spotifyDeviceId, this.device.spotifyPlaylistUrl);
-        this.platform.spotifyApiWrapper.setShuffle(true, this.device.spotifyDeviceId);
+        await this.platform.spotifyApiWrapper.setShuffle(true, this.device.spotifyDeviceId);
       } else {
-        this.platform.spotifyApiWrapper.pause(this.device.spotifyDeviceId);
+        await this.platform.spotifyApiWrapper.pause(this.device.spotifyDeviceId);
       }
 
       this.activeState = value;
@@ -120,9 +120,9 @@ export class SpotifySpeakerAccessory {
       return;
     }
 
-    if (state.body.is_playing && this.isPlaying(playingHref, playingDeviceId)) {
+    if (state.body.is_playing && this.isPlaying(playingHref, playingDeviceId ?? undefined)) {
       this.activeState = state.body.is_playing;
-      this.currentVolume = state.body.device.volume_percent;
+      this.currentVolume = state.body.device.volume_percent || 0;
     } else {
       this.activeState = false;
       this.currentVolume = 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+/// <reference types="spotify-api" />
+
 export interface HomebridgeSpotifySpeakerDevice {
   deviceName: string;
   deviceType: string;
@@ -25,32 +27,8 @@ export interface WebapiError {
 
 /**
  * Ref: https://developer.spotify.com/documentation/web-api/reference/#/operations/get-information-about-the-users-current-playback
- *
- * Some attributes are missing here, I kept what
- * could be needed in the scope of the project
  */
 export interface SpotifyPlaybackState {
-  body: {
-    device: {
-      id: string;
-      is_active: boolean;
-      is_private_session: boolean;
-      is_restricted: boolean;
-      name: string;
-      type: string;
-      volume_percent: number;
-    };
-    shuffle_state: boolean;
-    repeat_state: string; // 'on', 'off'
-    timestamp: number;
-    context: {
-      href: string;
-      type: string; // 'playlist'
-      uri: string;
-    };
-    progress_ms: number;
-    currently_playing_type: string; // 'track'
-    is_playing: boolean;
-  };
+  body: SpotifyApi.CurrentPlaybackResponse;
   statusCode: number;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
-/// <reference types="spotify-api" />
-
 export interface HomebridgeSpotifySpeakerDevice {
   deviceName: string;
   deviceType: string;


### PR DESCRIPTION
Added the spotify-api types which are already a dependency of the Spotify node package. 

Also added some documentation on weird behavior I found trying to use Amazon Alexa devices. I discovered the device_id being returned from the API did not work for the pause/play API by using the Spotify developer console and seeing 404s in the network tab of Chrome devtools. Then, I went to the web Spotify player and looked at the network traffic in Chrome devtools while I started playback on the device in question and noticed the id Spotify was using to start playback was a substring of the other id.